### PR TITLE
Relmgmt 1232 version comparator incorrect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
     <dependencies>
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
+            <artifactId>bitbucket-branch-api</artifactId>
+            <scope>provided</scope>
+            <version>${bitbucket.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-api</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2017 Vestmark, Inc.
+    
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except 
+    in compliance with the License. You may obtain a copy of the License at
+    
+        http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express 
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <name>Vestmark</name>
         <url>http://www.vestmark.com/</url>
     </organization>
-    <name>Merge Conflict Detector</name>
+    <name>AutoMerge Conflict Detector</name>
     <description>
         This is the Merge Conflict Detector plugin for Atlassian Bitbucket Server.
         It exposes potential automerge conflicts.

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!--
-    Copyright 2017 Vestmark, Inc.
-    
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except 
-    in compliance with the License. You may obtain a copy of the License at
-    
-        http://www.apache.org/licenses/LICENSE-2.0
-    
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express 
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
--->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -21,12 +6,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vestmark.bitbucket</groupId>
     <artifactId>automergeconflictdetector</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <organization>
         <name>Vestmark</name>
         <url>http://www.vestmark.com/</url>
     </organization>
-    <name>AutoMerge Conflict Detector</name>
+    <name>Merge Conflict Detector</name>
     <description>
         This is the Merge Conflict Detector plugin for Atlassian Bitbucket Server.
         It exposes potential automerge conflicts.
@@ -133,9 +118,9 @@
     </build>
 
     <properties>
-        <bitbucket.version>5.0.1</bitbucket.version>
-        <bitbucket.data.version>{$bitbucket.version}</bitbucket.data.version>
-        <amps.version>6.3.0</amps.version>
+        <bitbucket.version>5.6.0</bitbucket.version>
+        <bitbucket.data.version>5.6.0</bitbucket.data.version>
+        <amps.version>6.3.13</amps.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.3</atlassian.spring.scanner.version>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetector.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetector.java
@@ -17,6 +17,8 @@ package com.vestmark.bitbucket.plugin;
 import java.util.List;
 import java.util.LinkedList;
 
+import org.apache.commons.lang3.math.NumberUtils;
+
 import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestRef;
 import com.atlassian.bitbucket.repository.Branch;
@@ -128,6 +130,19 @@ public class MergeConflictDetector
     mergeResults.add(new MergeResult(toBranch, mergeConflicts, messages, files));
   }
 
+  public boolean isRelated(Branch toBranch)
+  {
+    String family = toBranchName.replaceAll("release\\/([^\\.|-]*).*", "$1");
+    String toBranchFamily = toBranch.getDisplayId().replaceAll("release\\/([^\\.|-]*).*", "$1");
+    if (NumberUtils.isNumber(family) && NumberUtils.isNumber(toBranchFamily)) {
+      return true;
+    }
+    if (family.equals(toBranchFamily)) {
+      return true;
+    }
+    return false;
+  }
+  
   public boolean isUpstreamBranch(Branch toBranch)
   {
     return VersionComparator.AS_STRING.compare(toBranch.getDisplayId(), toBranchName) >= 0 ? true : false;

--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetector.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetector.java
@@ -130,17 +130,9 @@ public class MergeConflictDetector
     mergeResults.add(new MergeResult(toBranch, mergeConflicts, messages, files));
   }
 
-  public boolean isRelated(Branch toBranch)
+  public boolean isRelated(Branch otherBranch)
   {
-    String family = toBranchName.substring(toBranchName.lastIndexOf("/")).replaceAll("\\/([^\\.|-]*).*", "$1");
-    String toBranchFamily = toBranch.getDisplayId().substring(toBranch.getDisplayId().lastIndexOf("/")).replaceAll("\\/([^\\.|-]*).*", "$1");
-    if (NumberUtils.isNumber(family) && NumberUtils.isNumber(toBranchFamily)) {
-      return true;
-    }
-    if (family.equals(toBranchFamily)) {
-      return true;
-    }
-    return false;
+    return VersionComparator.AS_STRING.getFamily(otherBranch.getDisplayId()).equals(VersionComparator.AS_STRING.getFamily(toBranchName));
   }
   
   public boolean isUpstreamBranch(Branch toBranch)

--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetector.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetector.java
@@ -132,8 +132,8 @@ public class MergeConflictDetector
 
   public boolean isRelated(Branch toBranch)
   {
-    String family = toBranchName.replaceAll("release\\/([^\\.|-]*).*", "$1");
-    String toBranchFamily = toBranch.getDisplayId().replaceAll("release\\/([^\\.|-]*).*", "$1");
+    String family = toBranchName.substring(toBranchName.lastIndexOf("/")).replaceAll("\\/([^\\.|-]*).*", "$1");
+    String toBranchFamily = toBranch.getDisplayId().substring(toBranch.getDisplayId().lastIndexOf("/")).replaceAll("\\/([^\\.|-]*).*", "$1");
     if (NumberUtils.isNumber(family) && NumberUtils.isNumber(toBranchFamily)) {
       return true;
     }

--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
@@ -35,8 +35,6 @@ import com.atlassian.bitbucket.repository.RepositoryBranchesRequest;
 import com.atlassian.bitbucket.pull.PullRequestSupplier;
 import com.atlassian.bitbucket.scm.MergeCommandParameters;
 import com.atlassian.bitbucket.scm.MergeException;
-import com.atlassian.bitbucket.ServiceException;
-import com.atlassian.bitbucket.scm.CommandFailedException;
 import com.atlassian.bitbucket.scm.git.command.GitExtendedCommandFactory;
 import com.atlassian.bitbucket.scm.git.command.merge.GitMergeException;
 import com.atlassian.bitbucket.scm.git.command.merge.conflict.GitMergeConflict;

--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Map;
-import java.lang.reflect.Method;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;

--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Map;
+import java.lang.reflect.Method;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -92,8 +93,8 @@ public class MergeConflictDetectorServlet
         pullRequestSupplier.getById(repoId, pullRequestId), hostUrl);
     BranchClassifier bc = modelService.getModel(mcd.getToRepo()).getClassifier();
     BranchType toBranchType = bc.getType(mcd.getToBranch());
-    // If the target is not master, find target branch and upstream releases (if any).
-    if (!mcd.getToBranchId().equals("refs/heads/master")) {
+    // If the target is not master and is a release branch, find target branch and upstream releases (if any).
+    if (toBranchType.getId().equals("RELEASE") && !mcd.getToBranchId().equals("refs/heads/master")) {
       Page<Branch> branches = bc.getBranchesByType(toBranchType, new PageRequestImpl(0,PageRequestImpl.MAX_PAGE_LIMIT/2));
       branches.stream()
               .filter(b -> mcd.isRelated(b))

--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
@@ -85,9 +85,7 @@ public class MergeConflictDetectorServlet
     
     // If the target is not master, find target branch and upstream releases (if any).
     if (!mcd.getToBranchId().equals("refs/heads/master")) {
-      //String toBranchNamePrefix = mcd.getToBranchName().replaceAll("release\\/([^0-9]*).*", "release/$1");
       String toBranchNamePrefix = mcd.getToBranchName().replaceAll("release\\/.*", "release/");
-      System.out.println("filterText = " + toBranchNamePrefix);
       RepositoryBranchesRequest repoBranchesRequest = new RepositoryBranchesRequest
           .Builder(mcd.getToRepo())
           .filterText(toBranchNamePrefix)

--- a/src/main/java/com/vestmark/bitbucket/plugin/VersionComparator.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/VersionComparator.java
@@ -53,7 +53,7 @@ public class VersionComparator<T>
       }
       else {
         // If we made it here, we are at the same split index in each version and there is at least one string in the comparison.
-        // Example, 8.1.1 versus 8.1-statefarm
+        // Example, 8.1.1 versus 8.1-text
         // If Left is a number and Right is a string that is not master, then Left is downstream from Right
         if (NumberUtils.isNumber(l[i]) && !NumberUtils.isNumber(r[i]) && r.length != 1) {
           return 1;
@@ -72,7 +72,7 @@ public class VersionComparator<T>
     // But the longer version might have a string value on the end and not an integer
     // Check if a version has a string value before doing the simple length comparison.
     // A version with a string value should register upstream.
-    // Example, 8.1 versus 8.1-statefarm.  8.1 is downstream from 8.1-statefarm.
+    // Example, 8.1 versus 8.1-text.  8.1 is downstream from 8.1-text.
     if (!NumberUtils.isNumber(l[l.length-1])) {
       return -1;
     }

--- a/src/main/java/com/vestmark/bitbucket/plugin/VersionComparator.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/VersionComparator.java
@@ -41,9 +41,10 @@ public class VersionComparator<T>
 
   public int compare(T o1, T o2)
   {
-    String[] l = valueMapper.apply(o1).replaceAll("release\\/","").split(splitPattern);
-    String[] r = valueMapper.apply(o2).replaceAll("release\\/","").split(splitPattern);
+    String[] l = valueMapper.apply(o1).split(splitPattern);
+    String[] r = valueMapper.apply(o2).split(splitPattern);
     int length = l.length < r.length ? l.length : r.length;
+    System.out.println("Main Compare " +  valueMapper.apply(o1) + " and "+ valueMapper.apply(o2));
     for (int i = 0; i < length; i++) {
       int result = 0;
       if (NumberUtils.isNumber(l[i]) && NumberUtils.isNumber(r[i])) {
@@ -52,8 +53,8 @@ public class VersionComparator<T>
         result = leftInt.compareTo(rightInt);
       }
       else {
-        // If we made it here, there is at least one string in the comparison.
-        // Example, 8.1 versus ubs-8.0.10
+        // If we made it here, we are at the same split index in each version and there is at least one string in the comparison.
+        // Example, 8.1.1 versus 8.1-statefarm
         // If Left is a number and Right is a string that is not master, then Left is downstream from Right
         if (NumberUtils.isNumber(l[i]) && !NumberUtils.isNumber(r[i]) && r.length != 1) {
           return 1;
@@ -65,28 +66,34 @@ public class VersionComparator<T>
         result = l[i].compareTo(r[i]);
       }
       if (result != 0) {
+        System.out.println("Returning " + result);
         return result;
       }
     }
-    // If we made it here, we have two versions of unequal lengths, with equal split values up to the shorter of the two
+    // If we are here, we have two versions of unequal lengths, with equal split values up to the shorter of the two
     // But the longer version might have a string value on the end and not an integer
     // Check if a version has a string value before doing the simple length comparison.
     // A version with a string value should register upstream.
     // Example, 8.1 versus 8.1-statefarm.  8.1 is downstream from 8.1-statefarm.
     if (!NumberUtils.isNumber(l[l.length-1])) {
+      System.out.println("String found in Left, Returning -1");
       return -1;
     }
     if (!NumberUtils.isNumber(r[r.length-1])) {
+      System.out.println("String found in right, Returning 1");
       return 1;
     }
     // If we made it here, a simple length comparison will do.
     // Example, 8.1 versus 8.1.1.  8.1 is upstream from 8.1.1.
     if (l.length < r.length) {
+      System.out.println("Left is shorter, Returning -1");
       return -1;
     }
     if (l.length > r.length) {
+      System.out.println("Left is larger, Returning 1");
       return 1;
     }
+    System.out.println("Returning 0");
     return 0;
   }
 }

--- a/src/main/java/com/vestmark/bitbucket/plugin/VersionComparator.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/VersionComparator.java
@@ -41,8 +41,8 @@ public class VersionComparator<T>
 
   public int compare(T o1, T o2)
   {
-    String[] l = valueMapper.apply(o1).split(splitPattern);
-    String[] r = valueMapper.apply(o2).split(splitPattern);
+    String[] l = valueMapper.apply(o1).replaceAll("release\\/","").split(splitPattern);
+    String[] r = valueMapper.apply(o2).replaceAll("release\\/","").split(splitPattern);
     int length = l.length < r.length ? l.length : r.length;
     for (int i = 0; i < length; i++) {
       int result = 0;
@@ -52,12 +52,35 @@ public class VersionComparator<T>
         result = leftInt.compareTo(rightInt);
       }
       else {
+        // If we made it here, there is at least one string in the comparison.
+        // Example, 8.1 versus ubs-8.0.10
+        // If Left is a number and Right is a string that is not master, then Left is downstream from Right
+        if (NumberUtils.isNumber(l[i]) && !NumberUtils.isNumber(r[i]) && r.length != 1) {
+          return 1;
+        }
+        // If Left is a string that is not master and Right is a number, then Left is upstream from Right
+        if (!NumberUtils.isNumber(l[i]) && NumberUtils.isNumber(r[i]) && l.length != 1) {
+          return -1;
+        }
         result = l[i].compareTo(r[i]);
       }
       if (result != 0) {
         return result;
       }
     }
+    // If we made it here, we have two versions of unequal lengths, with equal split values up to the shorter of the two
+    // But the longer version might have a string value on the end and not an integer
+    // Check if a version has a string value before doing the simple length comparison.
+    // A version with a string value should register upstream.
+    // Example, 8.1 versus 8.1-statefarm.  8.1 is downstream from 8.1-statefarm.
+    if (!NumberUtils.isNumber(l[l.length-1])) {
+      return -1;
+    }
+    if (!NumberUtils.isNumber(r[r.length-1])) {
+      return 1;
+    }
+    // If we made it here, a simple length comparison will do.
+    // Example, 8.1 versus 8.1.1.  8.1 is upstream from 8.1.1.
     if (l.length < r.length) {
       return -1;
     }

--- a/src/main/java/com/vestmark/bitbucket/plugin/VersionComparator.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/VersionComparator.java
@@ -39,10 +39,25 @@ public class VersionComparator<T>
     this.splitPattern = splitPattern;
   }
 
+  public String getFamily(String branchName) {
+    String[] branchComponents = branchName.split("\\/");
+    int prefixLength = branchComponents[0].length();
+    int versionLength = branchComponents[branchComponents.length-1].replaceAll("[A-Za-z]*(-?.*)$","$1").length();
+    // Family is everything in the branch name between the prefix and the version, exclusively
+    return branchName.substring(prefixLength + 1, branchName.length() - versionLength);
+  }
+
+  public String getVersion(String branchName) {
+    String[] branchComponents = branchName.split("\\/");
+    return branchComponents[branchComponents.length-1].replaceAll("[A-Za-z]*-?(.*)$","$1");
+  }
+
   public int compare(T o1, T o2)
   {
-    String[] l = valueMapper.apply(o1).split(splitPattern);
-    String[] r = valueMapper.apply(o2).split(splitPattern);
+    // If we are here, we can be guaranteed that the branches being compared are in the same family due to prior filtering.
+    // So all we want for comparison is the version.
+    String[] l = getVersion(valueMapper.apply(o1)).split(splitPattern);
+    String[] r = getVersion(valueMapper.apply(o2)).split(splitPattern);
     int length = l.length < r.length ? l.length : r.length;
     for (int i = 0; i < length; i++) {
       int result = 0;
@@ -62,7 +77,8 @@ public class VersionComparator<T>
         if (!NumberUtils.isNumber(l[i]) && NumberUtils.isNumber(r[i]) && l.length != 1) {
           return -1;
         }
-        result = l[i].compareTo(r[i]);
+        // If we are here, must be two strings.  A simple comparison will do.
+        return l[i].compareTo(r[i]);
       }
       if (result != 0) {
         return result;

--- a/src/main/java/com/vestmark/bitbucket/plugin/VersionComparator.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/VersionComparator.java
@@ -44,7 +44,6 @@ public class VersionComparator<T>
     String[] l = valueMapper.apply(o1).split(splitPattern);
     String[] r = valueMapper.apply(o2).split(splitPattern);
     int length = l.length < r.length ? l.length : r.length;
-    System.out.println("Main Compare " +  valueMapper.apply(o1) + " and "+ valueMapper.apply(o2));
     for (int i = 0; i < length; i++) {
       int result = 0;
       if (NumberUtils.isNumber(l[i]) && NumberUtils.isNumber(r[i])) {
@@ -66,7 +65,6 @@ public class VersionComparator<T>
         result = l[i].compareTo(r[i]);
       }
       if (result != 0) {
-        System.out.println("Returning " + result);
         return result;
       }
     }
@@ -76,24 +74,19 @@ public class VersionComparator<T>
     // A version with a string value should register upstream.
     // Example, 8.1 versus 8.1-statefarm.  8.1 is downstream from 8.1-statefarm.
     if (!NumberUtils.isNumber(l[l.length-1])) {
-      System.out.println("String found in Left, Returning -1");
       return -1;
     }
     if (!NumberUtils.isNumber(r[r.length-1])) {
-      System.out.println("String found in right, Returning 1");
       return 1;
     }
     // If we made it here, a simple length comparison will do.
     // Example, 8.1 versus 8.1.1.  8.1 is upstream from 8.1.1.
     if (l.length < r.length) {
-      System.out.println("Left is shorter, Returning -1");
       return -1;
     }
     if (l.length > r.length) {
-      System.out.println("Left is larger, Returning 1");
       return 1;
     }
-    System.out.println("Returning 0");
     return 0;
   }
 }


### PR DESCRIPTION
Could not reproduce the plugin crash on execution when a PR has already been merged.  
But I was able to reproduce and fix a crash involving improper casting of an exception object.
I also fixed the semantic ordering issues.
 

