### PR TITLE
RELMGMT-1464 toBranchType.getId() returns null if branch = master.  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vestmark.bitbucket</groupId>
     <artifactId>automergeconflictdetector</artifactId>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
     <organization>
         <name>Vestmark</name>
         <url>http://www.vestmark.com/</url>

--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
@@ -93,7 +93,7 @@ public class MergeConflictDetectorServlet
     BranchClassifier bc = modelService.getModel(mcd.getToRepo()).getClassifier();
     BranchType toBranchType = bc.getType(mcd.getToBranch());
     // If the target is not master and is a release branch, find target branch and upstream releases (if any).
-    if (toBranchType.getId().equals("RELEASE") && !mcd.getToBranchId().equals("refs/heads/master")) {
+    if (!mcd.getToBranchId().equals("refs/heads/master") && toBranchType.getId().equals("RELEASE") ) {
       Page<Branch> branches = bc.getBranchesByType(toBranchType, new PageRequestImpl(0,PageRequestImpl.MAX_PAGE_LIMIT/2));
       branches.stream()
               .filter(b -> mcd.isRelated(b))

--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
@@ -139,26 +139,33 @@ public class MergeConflictDetectorServlet
         .build();
     try {
       Branch result = extendedCmdFactory.merge(mcd.getToRepo(), params).call();
-      // A result from the merge indicates an unsuccesful dry run!
+      // A result from the merge indicates an unsuccessful dry run!
       if (result != null) {
         message.add("Merge committed! Commit ID: " + result.getLatestCommit());
       }
-    } catch (MergeException e) {
-      files = new LinkedList<String>();
-      mergeConflicts = new LinkedList<GitMergeConflict>();
-      // When a merge cannot be completed automatically, a CommandFailedException is being thrown and caught in this MergeException block by mistake.
-      // The (GitMergeException) cast below causes the plugin to crash because of it.
-      // Adding a CommandFailedException catch block did not work.
-      // Checking the type of the Exception obj prior to the cast using instanceof did not work.
-      // Encasing the cast inside its own try/catch was the only way I could find to keep the plugin from crashing.
-      try {
-        for (GitMergeConflict mergeConflict : ((GitMergeException)e.getCause()).getConflicts()) {
-          files.add(mergeConflict.getMessage().replaceFirst("Merge conflict in ", ""));
-          message.add("Source change: " + mergeConflict.getOurChange() + " Target change: " 
-                                        + mergeConflict.getTheirChange());
-          mergeConflicts.add(mergeConflict);
+    } catch (Exception e) {
+      if (e instanceof MergeException) {
+        System.out.println("Merge Exception Caught");
+        files = new LinkedList<String>();
+        mergeConflicts = new LinkedList<GitMergeConflict>();
+        // When a merge cannot be completed automatically, a CommandFailedException is being thrown and caught in this MergeException block by mistake.
+        // The (GitMergeException) cast below causes the plugin to crash because of it.
+        // Adding a CommandFailedException catch block did not work.
+        // Checking the type of the Exception obj prior to the cast using instanceof did not work.
+        // Encasing the cast inside its own try/catch was the only way I could find to keep the plugin from crashing.
+        try {
+          for (GitMergeConflict mergeConflict : ((GitMergeException)e.getCause()).getConflicts()) {
+            files.add(mergeConflict.getMessage().replaceFirst("Merge conflict in ", ""));
+            message.add("Source change: " + mergeConflict.getOurChange() + " Target change: " 
+                                          + mergeConflict.getTheirChange());
+            mergeConflicts.add(mergeConflict);
+          }
+        } catch (Exception f) {
+          message.add(e.getMessage());
         }
-      } catch (Exception f) {
+      } else {
+        // Non Merge Exception
+        System.out.println("Non Merge Exception Caught" + e.getMessage());
         message.add(e.getMessage());
       }
     }

--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
@@ -145,7 +145,6 @@ public class MergeConflictDetectorServlet
       }
     } catch (Exception e) {
       if (e instanceof MergeException) {
-        System.out.println("Merge Exception Caught");
         files = new LinkedList<String>();
         mergeConflicts = new LinkedList<GitMergeConflict>();
         // When a merge cannot be completed automatically, a CommandFailedException is being thrown and caught in this MergeException block by mistake.
@@ -165,11 +164,9 @@ public class MergeConflictDetectorServlet
         }
       } else {
         // Non Merge Exception
-        System.out.println("Non Merge Exception Caught" + e.getMessage());
         message.add(e.getMessage());
       }
     }
-
     mcd.addResult(toBranch, mergeConflicts, message, files);
   }
 }

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -31,6 +31,9 @@
         <label key="mcd.conflicts.tab">Merge Conflicts</label>
         <link>/plugins/servlet/mcd/${repository.id}/${pullRequest.id}</link>
         <tooltip key="mcd.conflicts.tab.tooltip"></tooltip>
+        <condition class="com.atlassian.bitbucket.web.conditions.PullRequestInState">
+          <param name="state">OPEN</param>
+        </condition>
     </web-item>
 
     <web-resource key="mcd-css" name="Merge Conflict Detector CSS">


### PR DESCRIPTION
Switched ordering of if statement to check if the branch is master before checking the branch type.  No crash.  And no existing functionality affected.  Tested.