### PR TITLE
Detector still crashes if merging to non-master, non-release branch

### DIFF
--- a/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
+++ b/src/main/java/com/vestmark/bitbucket/plugin/MergeConflictDetectorServlet.java
@@ -93,7 +93,7 @@ public class MergeConflictDetectorServlet
     BranchClassifier bc = modelService.getModel(mcd.getToRepo()).getClassifier();
     BranchType toBranchType = bc.getType(mcd.getToBranch());
     // If the target is not master and is a release branch, find target branch and upstream releases (if any).
-    if (!mcd.getToBranchId().equals("refs/heads/master") && toBranchType.getId().equals("RELEASE") ) {
+    if (!mcd.getToBranchId().equals("refs/heads/master") && toBranchType != null && toBranchType.getId().equals("RELEASE") ) {
       Page<Branch> branches = bc.getBranchesByType(toBranchType, new PageRequestImpl(0,PageRequestImpl.MAX_PAGE_LIMIT/2));
       branches.stream()
               .filter(b -> mcd.isRelated(b))


### PR DESCRIPTION
toBranchType has to be checked before calling getId() method.  No way around it.  It is null not only for master, but for "custom" branch types as well.